### PR TITLE
ci: install mdbook-katex

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,8 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install mdbook-katex
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to set up a stable Rust environment and install the mdbook-katex plugin before building documentation for GitHub Pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->